### PR TITLE
Fixed the xml parsing error described in issue #9

### DIFF
--- a/qgswcsclient2dialog.py
+++ b/qgswcsclient2dialog.py
@@ -342,7 +342,7 @@ class QgsWcsClient2Dialog(QtGui.QDialog, Ui_QgsWcsClient2):
         global offered_version
         
         join_xml = ''.join(in_xml)
-        tree1 = etree.fromstring(join_xml)
+        tree1 = etree.XML(join_xml)
 
             # get the required information from the GetCapabilitiy response
         outformat = tree1.xpath("wcs:ServiceMetadata/wcs:formatSupported/text()", namespaces=namespacemap)


### PR DESCRIPTION
I changed "fromstring" to "XML" as we are working with an XML not a string here.
Now I can connect to the two new you servers you provided, as well as to my local Rasdaman instance. The GetCapabilites & DescribeCoverage Tabs are working 100% 